### PR TITLE
Update Lightning Charge to 0.3.15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,12 +50,12 @@ services:
 
   lightning-charged:
     restart: always
-    image: shesek/lightning-charge:0.3.9
+    image: shesek/lightning-charge:0.3.15
     environment:
       NETWORK: ${NBITCOIN_NETWORK:-regtest}
       API_TOKEN: ${CHARGED_API_TOKEN}
       LN_ALIAS: ${CHARGED_ALIAS}
-      LIGHTNINGD_OPT: "--ipaddr=${CHARGED_IP}"
+      LIGHTNINGD_OPT: "--bind-addr=127.0.0.1:9735 --announce-addr=${CHARGED_IP}"
       VIRTUAL_NETWORK: nginx-proxy
       VIRTUAL_PORT: 9112
       VIRTUAL_HOST: ${CHARGED_HOST}


### PR DESCRIPTION
Updating to this version requires new lightningd parameters. It replaces 'ipaddr' with 'bind-addr' and 'announce-addr'.